### PR TITLE
Full noaa_sdk data and unlimited alerts supprt

### DIFF
--- a/custom_components/noaa_alerts/sensor.py
+++ b/custom_components/noaa_alerts/sensor.py
@@ -5,12 +5,17 @@ For more details about this component, please refer to the documentation at
 https://github.com/dcshoecomp/noaa_alerts
 """
 
+import logging
+import json
+
 import voluptuous as vol
 from datetime import timedelta
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.switch import (PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_LATITUDE, CONF_LONGITUDE)
+
+_LOGGER = logging.getLogger(__name__)
 
 __version_ = '0.0.4'
 
@@ -49,19 +54,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([noaa_alertsSensor(zoneid, event_urgency, event_severity, latitude, longitude)])
 
 def sortedbyurgencyandseverity(prop):
-    if (prop['properties']['urgency']).lower() == 'immediate':
+    if (prop['urgency']).lower() == 'immediate':
         sortedvalue = 1
-    elif (prop['properties']['urgency']).lower() == 'expected':
+    elif (prop['urgency']).lower() == 'expected':
         sortedvalue = 10
-    elif (prop['properties']['urgency']).lower() == 'future':
+    elif (prop['urgency']).lower() == 'future':
         sortedvalue = 100
     else:
         sortedvalue = 1000
-    if (prop['properties']['severity']).lower() == 'extreme':
+    if (prop['severity']).lower() == 'extreme':
         sortedvalue = sortedvalue * 1
-    elif (prop['properties']['severity']).lower() == 'severe':
+    elif (prop['severity']).lower() == 'severe':
         sortedvalue = sortedvalue * 2
-    elif (prop['properties']['severity']).lower() == 'moderate':
+    elif (prop['severity']).lower() == 'moderate':
         sortedvalue = sortedvalue * 3
     else:
         sortedvalue = sortedvalue * 4
@@ -84,49 +89,22 @@ class noaa_alertsSensor(Entity):
             params={'point': '{0},{1}'.format(self.latitude,self.longitude)}
         try:
             nws = noaa.NOAA().alerts(active=1, **params)
-            nwsalerts = nws['features']
-            if len(nwsalerts) > 1:
-                nwsalerts = sorted(nwsalerts, key=sortedbyurgencyandseverity)
-                self._state = nwsalerts[0]['properties']['urgency']
-                self._event_type = nwsalerts[0]['properties']['event']
-                self._event_severity = nwsalerts[0]['properties']['severity']
-                self._description = nwsalerts[0]['properties']['description']
-                self._headline = nwsalerts[0]['properties']['headline']
-                self._instruction = nwsalerts[0]['properties']['instruction']
-                #second set of events
-                self._state2 = nwsalerts[0]['properties']['urgency']
-                self._event_type2 = nwsalerts[0]['properties']['event']
-                self._event_severity2 = nwsalerts[0]['properties']['severity']
-                self._description2 = nwsalerts[0]['properties']['description']
-                self._headline2 = nwsalerts[0]['properties']['headline']
-                self._instruction2 = nwsalerts[0]['properties']['instruction']
-            elif len(nwsalerts) == 1:
-                self._state = nwsalerts[0]['properties']['urgency']
-                self._event_type = nwsalerts[0]['properties']['event']
-                self._event_severity = nwsalerts[0]['properties']['severity']
-                self._description = nwsalerts[0]['properties']['description']
-                self._headline = nwsalerts[0]['properties']['headline']
-                self._instruction = nwsalerts[0]['properties']['instruction']
-                self._state2 = 'none'
-            else:
-                self._state = 'none'
-                self._event_type = 'none'
-                self._event_severity = 'none'
-                self._headline = 'none'
-                self._instruction = 'none'
-                self._description = 'none'
-                self._state2 = 'none'
+            nwsalerts = []
+            for alert in nws['features'] :
+                nwsalerts.append(alert['properties'])
+            self._state = len(nwsalerts)
+            self._attributes = {}
+            self._attributes['alerts'] = sorted(nwsalerts, key=sortedbyurgencyandseverity)
+            self._attributes['alerts_string'] = json.dumps(self._attributes['alerts'])
         except Exception as err:
-            self._state = 'Error'
-            self._event_type = 'none'
-            self._event_severity = 'none'
-            self._headline = 'none'
-            self._instruction = 'none'
-            self._description = err
+            _LOGGER.error(err)
 
     @property
     def name(self):
-        return 'noaa_alerts'
+        name = "NOAA Alerts"
+        if self._zoneid != 'LAT,LONG':
+            name += ' (' + self._zoneid + ')'
+        return name
 
     @property
     def state(self):
@@ -138,26 +116,5 @@ class noaa_alertsSensor(Entity):
 
     @property
     def device_state_attributes(self):
-        if self._state2 == 'none':
-            return {
-                ATTR_EVENT: self._event_type,
-                ATTR_SEVERITY: self._event_severity,
-                ATTR_HEADLINE: self._headline,
-                ATTR_INSTRUCTION: self._instruction,
-                ATTR_DESCRIPTION: self._description,
-            }
-        else:
-            return {
-                ATTR_EVENT: self._event_type,
-                ATTR_SEVERITY: self._event_severity,
-                ATTR_HEADLINE: self._headline,
-                ATTR_INSTRUCTION: self._instruction,
-                ATTR_DESCRIPTION: self._description,
-                'urgency2': self._state2,
-                'event2': self._event_type2,
-                'severity2': self._event_severity2,
-                'headline2': self._headline2,
-                'instruction2': self._instruction2,
-                'description2': self._description2,
-            }
-
+        """Return the attributes of the sensor."""
+        return self._attributes


### PR DESCRIPTION
Not sure if you're interested in these changes - I made them for my personal use but I thought others may find them useful. There's two main things that I changed:

1. I changed the attributes to have an `alert` attribute with the full noaa_sdk properties. There was some stuff in there that you didn't include that I'm using (NWSheadline & expires). I just kept this an object, so if there's multiple alerts it's simply an array with the properties of each alert. Doing it this way simplifies the code and also doesn't limit the number of alerts to 2. In the popup-card in the front end this is just displayed as `[object Object]` so I also included an alerts_string attribute that's a json representation of alerts, mostly just for easier reference.

2. I changed the state to be the number of alerts there are. This could be obtained by getting the size of the alerts object, but it's a lot easier for triggering automations, etc., if the data is readily available. I also personally feel it's more appropriate than simply choosing the urgency of the first alert, and it's how Weather Underground alerts were.

I also made a slight tweak to entity name, which would be helpful if someone configures multiple instances.

Like I said, no worries if this isn't the direction you want to take the component. I already made the adjustments for my use so I figured a PR wouldn't hurt!